### PR TITLE
py3k support, sanity check for libLLVM glob (was: Travis CI + test case)

### DIFF
--- a/llvmcpy/llvm.py
+++ b/llvmcpy/llvm.py
@@ -466,6 +466,10 @@ def generate_wrapper():
 
     libs, ffi_code = parse_headers()
 
+    if len(libs) == 0:
+        raise ValueError("No valid LLVM libraries found' \
+            ', LLVM must be built with BUILD_SHARED_LIBS")
+
     classes = defaultdict(list)
     global_functions = []
     constants = []

--- a/llvmcpy/llvm.py
+++ b/llvmcpy/llvm.py
@@ -161,7 +161,7 @@ def create_function(library, name, prototype,
         zeroth_argument = ["self"] if is_class_method else []
         # Discard None arguments, they have been removed
         args = filter(lambda x: x is not None, function_arguments)
-        function_arguments_str = ", ".join(zeroth_argument + args)
+        function_arguments_str = ", ".join(zeroth_argument + list(args))
         return ("""
     def {}({}):
         """ + "\"\"\"See {}\"\"\"\n").format(method_name,


### PR DESCRIPTION
This is a (mostly) unrelated PR from the previous one.  Doesn't include the verification, just a CI config and a simple test case from the README.

Only change to the normal functionality is a sanity check for when the glob comes up empty.  I added this because with only `llvm` (without `libllvm`), it fails mysteriously.