### PR TITLE
Add Continuous Integration for multiple LLVM versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,10 @@ addons:
     - llvm-toolchain-trusty-3.9
     - llvm-toolchain-trusty-4.0
     packages:
-    - libllvm3.5
-    - llvm-3.5
-    - libllvm3.6
-    - llvm-3.6
-    - libllvm3.9
-    - llvm-3.9
-    - libllvm4.0
-    - llvm-4.0
+    - llvm-3.5-dev
+    - llvm-3.6-dev
+    - llvm-3.9-dev
+    - llvm-4.0-dev
 
 # on travis, clang-3.5 in /usr/local includes an llvm-config
 #   that comes earlier in the path than the system llvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: python
 python:
   - "2.7"
@@ -5,24 +6,24 @@ python:
 
 addons:
   apt:
+    sources:
+    - llvm-toolchain-trusty-3.9
+    - llvm-toolchain-trusty-4.0
     packages:
     - libllvm3.5
-    - llvm3.5
-    - libllvm3.7
-    - llvm3.7
-    - libllvm3.8
-    - llvm3.8
+    - llvm-3.5
+    - libllvm3.6
+    - llvm-3.6
     - libllvm3.9
-    - llvm3.9
+    - llvm-3.9
     - libllvm4.0
-    - llvm4.0
+    - llvm-4.0
 
 # on travis, clang-3.5 in /usr/local includes an llvm-config
 #   that comes earlier in the path than the system llvm
 env:
     - LLVM_CONFIG=/usr/bin/llvm-config-3.5
-    - LLVM_CONFIG=/usr/bin/llvm-config-3.7
-    - LLVM_CONFIG=/usr/bin/llvm-config-3.8
+    - LLVM_CONFIG=/usr/bin/llvm-config-3.6
     - LLVM_CONFIG=/usr/bin/llvm-config-3.9
     - LLVM_CONFIG=/usr/bin/llvm-config-4.0
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: python
+python:
+  - "2.7"
+  - "3.5"
+
+addons:
+  apt:
+    packages:
+    - libllvm3.5
+    - llvm3.5
+    - libllvm3.7
+    - llvm3.7
+    - libllvm3.8
+    - llvm3.8
+    - libllvm3.9
+    - llvm3.9
+    - libllvm4.0
+    - llvm4.0
+
+# on travis, clang-3.5 in /usr/local includes an llvm-config
+#   that comes earlier in the path than the system llvm
+env:
+    - LLVM_CONFIG=/usr/bin/llvm-config-3.5
+    - LLVM_CONFIG=/usr/bin/llvm-config-3.7
+    - LLVM_CONFIG=/usr/bin/llvm-config-3.8
+    - LLVM_CONFIG=/usr/bin/llvm-config-3.9
+    - LLVM_CONFIG=/usr/bin/llvm-config-4.0
+
+install: "pip install -e ."
+script:
+    - python setup.py test


### PR DESCRIPTION
This PR sets up Travis CI for testing multiple Python and – more importantly – multiple LLVM versions.

[Example Build](https://travis-ci.org/hperl/llvmcpy/builds/214957179)

This build already reveals an issue in the test code. LLVM versions 3.9 and 4.0 require the line `source_filename = "example.c"`, while LLVM versions 3.8 and lower generate an error.

These and other compatibility issues can easily be caught with this setup. I hope it proves useful!