### PR TITLE
Improve handling for sized string return values

### DIFF
--- a/llvmcpy/test.py
+++ b/llvmcpy/test.py
@@ -66,5 +66,12 @@ class TestSuite(unittest.TestCase):
 
         assert first_instruction.is_a_binary_operator() is None
 
+    def test_sized_string_return(self):
+        string = "a\0b\0c"
+        value = llvm.md_string(string, len(string))
+        self.assertEqual(value.get_md_string(), string)
+        self.assertEqual(value.get_md_string(encoding=None), string.encode('ascii'))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR fixes the second problem mentioned in issue #10:
functions that return strings and have an unsigned*/size_t*
argument in which the string length is written.

All such functions have the length out-argument as the last argument,
so I limited the detection to only check the last argument.
