### PR TITLE
Support LLVM 8.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ env:
   - LLVM_VERSION=4.0 PYTHON_VERSION=2
   - LLVM_VERSION=5.0 PYTHON_VERSION=2
   - LLVM_VERSION=6.0 PYTHON_VERSION=2
+  - LLVM_VERSION=7 PYTHON_VERSION=2
+  - LLVM_VERSION=8 PYTHON_VERSION=2
   - LLVM_VERSION=3.4 PYTHON_VERSION=3
   - LLVM_VERSION=3.5 PYTHON_VERSION=3
   - LLVM_VERSION=3.6 PYTHON_VERSION=3
@@ -25,6 +27,8 @@ env:
   - LLVM_VERSION=4.0 PYTHON_VERSION=3
   - LLVM_VERSION=5.0 PYTHON_VERSION=3
   - LLVM_VERSION=6.0 PYTHON_VERSION=3
+  - LLVM_VERSION=7 PYTHON_VERSION=3
+  - LLVM_VERSION=8 PYTHON_VERSION=3
 
 # Exclude LLVM versions not available on brew
 matrix:
@@ -64,6 +68,8 @@ addons:
       - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-4.0 main"
       - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main"
       - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main"
+      - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-7 main"
+      - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-8 main"
 
 before_install:
   - |

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ setup(
         'cffi>=1.0.0',
         'pycparser',
         'appdirs',
-        'shutilwhich'
+        'shutilwhich',
+        'packaging'
     ],
     test_suite="llvmcpy.test.TestSuite",
 )


### PR DESCRIPTION
This PR adds support for LLVM 8.0.
This requires to handle LLVM types starting not only with `struct LLVM` but with `LLVM` as well since such types appear in LLVM 8.0 C API. 
Also, some additional headers need to be put into headers blacklist.