### PR TITLE
Fix search path handling on non-Unix-like systems

### DIFF
--- a/llvmcpy/llvm.py
+++ b/llvmcpy/llvm.py
@@ -758,9 +758,9 @@ class {class_name}(object):
 """.format(name, values))
 
 # Add to PATH the output of llvm-config --bin-dir
-search_paths = os.environ.get("PATH")
+search_paths = os.environ.get("PATH", os.defpath)
 llvm_config = find_program("LLVM_CONFIG", ["llvm-config"])
-search_paths = run_llvm_config(["--bindir"]) + ":" + search_paths
+search_paths = run_llvm_config(["--bindir"]) + (search_paths and (os.pathsep + search_paths))
 
 cache_dir = appdirs.user_cache_dir('llvmcpy')
 version = run_llvm_config(["--version"])


### PR DESCRIPTION
Replace hard-coded Unix path separator (":") with `os.pathsep`