### PR TITLE
Update CI and use which from shutil for Python >=3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ os:
 osx_image: xcode9.3
 
 env:
-  - LLVM_VERSION=3.4 PYTHON_VERSION=2
   - LLVM_VERSION=3.5 PYTHON_VERSION=2
   - LLVM_VERSION=3.6 PYTHON_VERSION=2
   - LLVM_VERSION=3.7 PYTHON_VERSION=2
@@ -18,7 +17,6 @@ env:
   - LLVM_VERSION=6.0 PYTHON_VERSION=2
   - LLVM_VERSION=7 PYTHON_VERSION=2
   - LLVM_VERSION=8 PYTHON_VERSION=2
-  - LLVM_VERSION=3.4 PYTHON_VERSION=3
   - LLVM_VERSION=3.5 PYTHON_VERSION=3
   - LLVM_VERSION=3.6 PYTHON_VERSION=3
   - LLVM_VERSION=3.7 PYTHON_VERSION=3
@@ -34,8 +32,6 @@ env:
 matrix:
   exclude:
   - os: osx
-    env: LLVM_VERSION=3.4 PYTHON_VERSION=2
-  - os: osx
     env: LLVM_VERSION=3.5 PYTHON_VERSION=2
   - os: osx
     env: LLVM_VERSION=3.6 PYTHON_VERSION=2
@@ -43,8 +39,6 @@ matrix:
     env: LLVM_VERSION=3.7 PYTHON_VERSION=2
   - os: osx
     env: LLVM_VERSION=3.8 PYTHON_VERSION=2
-  - os: osx
-    env: LLVM_VERSION=3.4 PYTHON_VERSION=3
   - os: osx
     env: LLVM_VERSION=3.5 PYTHON_VERSION=3
   - os: osx
@@ -58,18 +52,9 @@ addons:
   apt:
     sources:
       - sourceline: "ppa:ubuntu-toolchain-r/test"
-      - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.4 main"
+      - sourceline: "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main"
         key_url: "http://apt.llvm.org/llvm-snapshot.gpg.key"
-      - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.5 main"
-      - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.6 main"
-      - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.7 main"
-      - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.8 main"
-      - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main"
-      - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-4.0 main"
-      - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main"
-      - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main"
-      - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-7 main"
-      - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-8 main"
+      - sourceline: "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main"
 
 before_install:
   - |
@@ -84,8 +69,8 @@ before_install:
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       sudo apt-get update
       sudo -E apt-get -yq --no-install-suggests --no-install-recommends \
-        --force-yes install -t llvm-toolchain-trusty-3.9 \
-        $PYTHON $PYTHON-pip llvm-$LLVM_VERSION-dev
+        --force-yes install \
+        $PYTHON $PYTHON-pip $PYTHON-setuptools llvm-$LLVM_VERSION-dev
       export LLVM_CONFIG=llvm-config-$LLVM_VERSION
     fi
 

--- a/llvmcpy/llvm.py
+++ b/llvmcpy/llvm.py
@@ -17,7 +17,11 @@ from cffi import FFI
 from glob import glob
 from itertools import chain
 from collections import defaultdict
-from shutilwhich import which
+# For Python version <3.3, shutil.which is provided by the shutilwhich module.
+try:
+    from shutil import which
+except ImportError:
+    from shutilwhich import which
 
 def run_llvm_config(args):
     """Invoke llvm-config with the specified arguments and return the output"""

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         'cffi>=1.0.0',
         'pycparser',
         'appdirs',
-        'shutilwhich',
+        'shutilwhich;python_version<"3.3"',
         'packaging'
     ],
     test_suite="llvmcpy.test.TestSuite",


### PR DESCRIPTION
This PR contains 2 features:
* The default environment for Travis CI is now Ubuntu 16.04 (Xenial). This requires to update the LLVM PPA repositories.
* Use `which` from `shutil` for Python >= 3.3. For older versions, keep using the backported version from the `shutilwhich` package.