### PR TITLE
Handle unsigned integer qualifiers

### DIFF
--- a/llvmcpy/llvm.py
+++ b/llvmcpy/llvm.py
@@ -543,6 +543,9 @@ def handle_enums(all_c_preprocessed):
     def handle_expression(variables, expression):
         expression_type = type(expression)
         if expression_type is pycparser.c_ast.Constant:
+            # Testing on LLVM 12+, some constants have the U qualifier which crashes
+            # when converting to an int, so just remove it here if it exists.
+            expression_type = expression_type.replace("U", "")
             return int(expression.value, 0)
         elif expression_type is pycparser.c_ast.ID:
             assert expression.name in variables

--- a/llvmcpy/llvm.py
+++ b/llvmcpy/llvm.py
@@ -543,8 +543,7 @@ def handle_enums(all_c_preprocessed):
     def handle_expression(variables, expression):
         expression_type = type(expression)
         if expression_type is pycparser.c_ast.Constant:
-            # Testing on LLVM 12+, some constants have the U qualifier which crashes
-            # when converting to an int, so just remove it here if it exists.
+            # Testing on LLVM 12+, some constants have the unsigned qualifier
             expression_type = expression_type.replace("U", "")
             return int(expression.value, 0)
         elif expression_type is pycparser.c_ast.ID:


### PR DESCRIPTION
This is just a 1 line fix that handles integer consts that have the unsigned modifier. 

In LLVM 12, there are a few consts like 1U which the python script fails to parse, this just removes the U if it's present. 

Let me know if there is something else you would like me to do in order for this to be merged. 

Also thanks for open sourcing this project, it's very useful. 