### PR TITLE
Allow versioned shared object files

### DIFF
--- a/llvmcpy/_generator.py
+++ b/llvmcpy/_generator.py
@@ -537,11 +537,14 @@ def iter_{self.normalize_name(class_name, iterated_name)}s(self):
         """Parse the header files of the LLVM-C API and produce a list of libraries
         and the CFFI cached data"""
 
+        lib_files = None
         # Take the list of LLVM libraries
         for lib_file in self.libraries:
-            if lib_file.name.startswith("libLLVM."):
+            # The library file could be libLLVM.{ext} or libLLVM-{version}.{ext}
+            if lib_file.name.startswith("libLLVM.") or lib_file.name.startswith("libLLVM-"):
                 lib_files = [lib_file]
                 break
+        assert lib_files, "Could not find libLLVM!"
 
         def recursive_chmod(path: Path):
             path.chmod(0o700)


### PR DESCRIPTION
Currently `llvmcpy` will panic on line `641` of `_generator.py` if it can't find `libLLVM.so` (on linux). However, some LLVM distributions (e.g. installing a specific LLVM version) will have the shared object named as `libLLVM-{version}.so`. It is possible to work around this by symlinking `libLLVM-{version}.so` to `libLLVM.so`.

This patch allows `llvmcpy` find the shared object in both cases without requiring users to set up their own symlinks. 